### PR TITLE
!$x and isset($x) is included in empty($x)

### DIFF
--- a/ps_newproducts.php
+++ b/ps_newproducts.php
@@ -111,7 +111,7 @@ class Ps_NewProducts extends Module implements WidgetInterface
 
             $productNbr = Tools::getValue('NEW_PRODUCTS_NBR');
 
-            if (!$productNbr || empty($productNbr)) {
+            if (empty($productNbr)) {
                 $output .= $this->displayError(
                     $this->trans('Please complete the "products to display" field.', array(), 'Modules.Newproducts.Admin' )
                 );


### PR DESCRIPTION
!$x and isset($x) is included in empty($x)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
