### PR TITLE
Reject non-numeric values in the products-to-display setting

### DIFF
--- a/ps_newproducts.php
+++ b/ps_newproducts.php
@@ -87,7 +87,7 @@ class Ps_NewProducts extends Module implements WidgetInterface
                 $output .= $this->displayError(
                     $this->trans('Please complete the "products to display" field.', [], 'Modules.Newproducts.Admin')
                 );
-            } elseif ((int) $productNbr === 0) {
+            } elseif (!Validate::isUnsignedInt($productNbr)) {
                 $output .= $this->displayError(
                     $this->trans('Invalid number.', [], 'Modules.Newproducts.Admin')
                 );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `getContent()` rejects an invalid "products to display" value with `(int) $productNbr === 0`, which only catches input that casts to zero. `3abc`, `-5` and `2.7` all pass it and are stored. This replaces that test with `Validate::isUnsignedInt()`, which is what the value actually has to be.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Follow-up to PrestaShop/PrestaShop#41351, which fixed only the `test` case.
| How to test?  | See the before/after table below.

#41351 restored the check for a purely non-numeric value, and `test` is rejected again. The check it restored is `(int) $productNbr === 0`, so it rejects exactly the inputs that cast to zero and nothing else.

Measured on a 9.2.0 shop with 2.0.1, calling `getContent()` with the real POST payload and reading `NEW_PRODUCTS_NBR` afterwards:

```
input      | message                                         | stored after
'test'     | Invalid number.                                 | unchanged
'3abc'     | The settings have been updated.                 | 3
'-5'       | The settings have been updated.                 | -5
'2.7'      | The settings have been updated.                 | 2
'0'        | Please complete the "products to display" field. | unchanged
''         | Please complete the "products to display" field. | unchanged
'8'        | The settings have been updated.                 | 8
```

`3abc` is silently truncated to `3` under a success message. `-5` is stored as-is; it does not raise anything downstream, it is quietly ignored - `Product::getNewProducts($idLang, 0, -5)` returns 10 rows, so the block renders ten products while the saved setting reads minus five.

With this change, same run:

```
input      | message                                         | stored after
'test'     | Invalid number.                                 | unchanged
'3abc'     | Invalid number.                                 | unchanged
'-5'       | Invalid number.                                 | unchanged
'2.7'      | Invalid number.                                 | unchanged
'0'        | Please complete the "products to display" field. | unchanged
''         | Please complete the "products to display" field. | unchanged
'8'        | The settings have been updated.                 | 8
```

The `empty()` branch is deliberately left ahead of the new check, so `0` and `''` keep answering "Please complete the field" exactly as before. That matters because the core UI test `tests/UI/campaigns/modules/29_ps_newproducts/02_configuration/01_configureSettingsProductsToDisplay.ts` asserts that pairing, and PrestaShop/PrestaShop#42204 is re-enabling its `test` case right now - neither needs to change for this.

`Validate::isUnsignedInt()` is present in `classes/Validate.php` on every PrestaShop version in this repository's PHPStan matrix, 1.7.1.2 through 8.0 and current, so the compatibility range is unaffected. I checked each tag rather than assuming.

Checks run locally: PHP-CS-Fixer with this repository's config, clean; `tests/phpstan.sh 8.0`, no errors; syntax check on 8.1, clean. `tests/phpstan.sh latest` fails here, but it fails identically on unmodified `dev` and in this repository's own CI - `RuntimeException ... platform_check.php ... require a PHP version ">= 8.1.0". You are running 7.4.20`, because the `prestashop/prestashop:latest` image now needs PHP 8.1 while the pinned `phpstan/phpstan:0.12` image runs 7.4. That is unrelated to this change and worth fixing separately.

There is no PHPUnit harness in this repository, so the verification above is the before/after rather than a test. If you would rather have the coverage as UI test cases, the array in that core spec takes `{setting: '3abc', error: invalidNumberMessage}` and `{setting: '-5', error: invalidNumberMessage}` without any new step definitions, and I will open that once a release carrying this change is out.
